### PR TITLE
Allow configuration parameters to be passed to json2dict

### DIFF
--- a/yajl.tcl
+++ b/yajl.tcl
@@ -15,8 +15,8 @@ namespace eval ::yajl {
 # format to parse than the direct output of the "get" method.
 # (inspired and named after the tcllib proc ::json::json2dict)
 #
-proc json2dict {jsonText} {
-	set obj [yajl create #auto]
+proc json2dict {jsonText args} {
+	set obj [yajl create #auto {*}$args]
 	set result [$obj parse2dict $jsonText]
 	$obj delete
 	return $result


### PR DESCRIPTION
These are expanded and passed to the parser constructor. This way, parser options might be used with
the json2dict interface too.
Example: set conf [::yajl::json2dict $data -allowComments 1]
