### PR TITLE
Mute a compiler warning about parseHandle not being initialized.

### DIFF
--- a/generic/yajltcl.c
+++ b/generic/yajltcl.c
@@ -858,7 +858,7 @@ yajltcl_yajlObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj
           case OPT_PARSE: {
               char *string;
               int   len;
-	      yajl_handle parseHandle;
+	      yajl_handle parseHandle = NULL;
 
               if (arg + 1 >= objc) {
                   Tcl_WrongNumArgs (interp, 1, objv, "parse jsonText");


### PR DESCRIPTION
Compilers whine about the default branch of the switch statement at line 868
leaving the variable parseHandle initialized. This is impossible since the
branch of the parent switch is only taken when optIndex actually has one of the
values checked by the child switch. Let's initialize parseHandle nonetheless,
just for the sake of compilers' peace of mind.