### PR TITLE
Add travis-ci.org configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+
+sudo: required
+
+before_install:
+  - apt-get install -y libyajl-dev
+  
+script:
+  - autoreconf -vi
+  - ./configure --with-tcl=/usr/lib/tclConfig.sh
+  - make
+  - sudo make install


### PR DESCRIPTION
We can get Linux and Mac OS CI builds for free on travis-ci.org.