### PR TITLE
Huddle fixes

### DIFF
--- a/generic/yajltcl.c
+++ b/generic/yajltcl.c
@@ -456,7 +456,7 @@ parse2huddle_boolean_callback (void *context, int boolean)
 {
     yajltcl_clientData *yajlData = context;
 
-    Tcl_DStringAppendElement (&yajlData->p2dString, boolean ? "1" : "0");
+    Tcl_DStringAppendElement (&yajlData->p2dString, boolean ? "b true" : "b false");
     return 1;
 }
 

--- a/generic/yajltcl.c
+++ b/generic/yajltcl.c
@@ -467,7 +467,7 @@ parse2huddle_number_callback (void *context, const char *s, size_t l)
 {
     yajltcl_clientData *yajlData = context;
 
-    Tcl_DStringAppend (&yajlData->p2dString, "{s ",3);
+    Tcl_DStringAppend (&yajlData->p2dString, "{num ", 5);
 
     Tcl_DStringSetLength (&yajlData->dString, 0);
     Tcl_DStringAppend (&yajlData->dString, s, l);

--- a/generic/yajltcl.c
+++ b/generic/yajltcl.c
@@ -445,7 +445,7 @@ parse2huddle_null_callback (void *context)
 {
     yajltcl_clientData *yajlData = context;
 
-    Tcl_DStringAppendElement (&yajlData->p2dString, "s null");
+    Tcl_DStringAppendElement (&yajlData->p2dString, "null");
     return 1;
 }
 

--- a/tests/huddle.test
+++ b/tests/huddle.test
@@ -25,10 +25,6 @@ namespace eval ::yajl::test {
 		set json_obj [yajl create #auto -beautify 0]
 		set yajlstr2 [$json_obj parse $json]
 		$json_obj delete
-
-		# TODO: test next 2 lines are just a hack because the conversion to huddle is lossy with number types?
-		set yajlstr [string map {number string} $yajlstr]
-		set yajlstr2 [string map {number string} $yajlstr2]
 		
 		if {$yajlstr2 != $yajlstr} {
 			puts "YAJL:\t\t$yajlstr"
@@ -66,10 +62,10 @@ namespace eval ::yajl::test {
 	} -result 1
 
 	# TODO: this test currently fails
-	# test 1.04 {: Array with null element
-	# } -body {
-	# 	dotest {{"moo": "cow", "pig": "oink", "rabbit" : null}}
-	# } -result 1
+	test 1.04 {: Array with null element
+	} -body {
+		dotest {{"moo": "cow", "pig": "oink", "rabbit" : null}}
+	} -result 1
 
 
 	test 1.05 {: example from the yajl-tcl README file.
@@ -154,6 +150,23 @@ namespace eval ::yajl::test {
 		}}
 	} -result 1
 
+	# HUDDLE {D {A {b true}}}
+	test 1.08 {: basic types boolean
+	} -body {
+		dotest {{"key": true}}
+	} -result 1
+
+	# HUDDLE {D {A {num 42}}}
+	test 1.09 {: basic types integer
+	} -body {
+		dotest {{"key": 42}}
+	} -result 1
+
+	# HUDDLE {D {A null}}
+	test 1.11 {: basic types null
+	} -body {
+		dotest {{"key": null}}
+	} -result 1
 }
 
 cleanupTests


### PR DESCRIPTION
I had some issues with large JSON inputs I was using huddle with - when switching from `::huddle::json2huddle` to `yajl::json2huddle` I encountered a few issues with incomplete huddle encoding of boolean and null types.  I also noticed numbers seem wrong as per what huddle encodes.

Tests and fixes proposed.